### PR TITLE
Fix CI/CD test configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
                   echo "Activating venv..."
                   source .venv/bin/activate
                 fi
-                COVERAGE_ARGS="--cov=mcp_nixos --cov-report=term-missing --cov-report=html --cov-report=xml"
+                COVERAGE_ARGS="--cov=mcp_nixos --cov-report=term --cov-report=html --cov-report=xml"
                 PYTEST_ARGS=""
                 for arg in "$@"; do
                   case $arg in

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = --verbose --cov=mcp_nixos --cov-report=term --cov-report=html --cov-report=xml
+addopts = --verbose
 asyncio_default_fixture_loop_scope = function
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
Resolves duplicate coverage arguments between pytest.ini and flake.nix that were causing test failures in CI/CD pipeline.