### PR TITLE
fix(docker): ensure container exits instantly without hanging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,21 @@ RUN pip install --no-cache-dir -e .
 RUN echo "Running pre-cache to populate cache data..." && \
     python -m mcp_nixos --pre-cache
 
-# Run the MCP server
-CMD ["python", "-m", "mcp_nixos"]
+# Set environment variables to ensure clean exit
+ENV PYTHONUNBUFFERED=1
+ENV MCP_NIXOS_CLEANUP_ORPHANS=true
+# Set low timeout values for all operations
+ENV MCP_NIXOS_SHUTDOWN_TIMEOUT=0.1
+ENV MCP_NIXOS_STARTUP_TIMEOUT=1.0
+
+# Use tini as init system to handle signals properly
+RUN apt-get update && apt-get install -y tini && rm -rf /var/lib/apt/lists/*
+
+# Use tini as entrypoint for proper signal forwarding and zombie reaping
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# Run the MCP server through the run.py wrapper for better termination handling
+CMD ["python", "-m", "mcp_nixos.run"]
+
+# Add signal handler to ensure container exits cleanly
+STOPSIGNAL SIGTERM


### PR DESCRIPTION
- Add tini as init system for proper signal forwarding and zombie reaping
- Use mcp_nixos.run wrapper for aggressive process termination
- Set low timeout values via environment variables
- Enable cleanup of orphan processes
- Add explicit STOPSIGNAL for Docker to use

🤖 Generated with [Claude Code](https://claude.ai/code)