### PR TITLE
Remove unnecessary build dependency from website deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@ jobs:
 
   deploy-website:
     name: Deploy Website to AWS S3
-    needs: [build, check-website-changes]
+    needs: [check-website-changes]
     if: github.ref == 'refs/heads/main' && needs.check-website-changes.outputs.website_changed == 'true'
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Make website deployment independent of Nix flake build since they use separate build systems and don't have a direct dependency. This allows the website deployment to run in parallel rather than waiting for the flake build to complete.

🤖 Generated with [Claude Code](https://claude.ai/code)