### PR TITLE
CI: Enable automatic website deployment to AWS S3/CloudFront

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # MCP-NixOS Website
 
-The official website for the MCP-NixOS project built with Next.js 15.2 and Tailwind CSS.
+The official website for the MCP-NixOS project built with Next.js 15.2 and Tailwind CSS. Deployed automatically via CI/CD to AWS S3 and CloudFront.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Add a new CI/CD workflow for automatic website deployment
- Deploy website to AWS S3 when files in website/ directory change
- Invalidate CloudFront cache after deployment
- Only run on the main branch (not on PRs)
- Completely independent from other CI jobs

## Test plan
- [x] Added descriptive information to website README
- [x] Used AWS environment and credentials for deployment
- [x] Configured for S3 bucket: urandom-mcp-nixos
- [x] Set CloudFront distribution ID: E1QS1G7FYYJ6TL

🤖 Generated with [Claude Code](https://claude.ai/code)