### PR TITLE
feat: add support for 25.05 beta channel with beta alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ venv.bak/
 *.swp
 *.swo
 *~
+.vscode/
 
 # Misc
 temp

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,46 +1,48 @@
-# MCP-NixOS: v0.4.0 Release Notes
+# MCP-NixOS: v0.5.0 Release Notes
 
 ## Overview
 
-MCP-NixOS v0.4.0 introduces significant architectural improvements, focusing on resolving critical issues with channel switching and context management. This release also includes a completely redesigned prompt system following Model Context Protocol (MCP) best practices for dynamic discovery.
+MCP-NixOS v0.5.0 introduces support for the NixOS 25.05 Beta channel, enhancing the flexibility and forward compatibility of the tool. This release adds the ability to search and query packages and options from the upcoming NixOS 25.05 release while maintaining backward compatibility with existing channels.
 
-## Changes in v0.4.0
+## Changes in v0.5.0
 
 ### 🚀 Major Enhancements
 
-- **Fixed Channel Switching Functionality**: Resolved issues with channel switching between stable and unstable NixOS versions, ensuring accurate data retrieval for different channels
-- **Improved Context Management**: Completely refactored context management to eliminate type confusion and provide consistent handling across all tools
-- **Dynamic Discovery Tools**: Implemented discovery tools following MCP best practices, enabling AI to explore available capabilities dynamically
-- **Redesigned MCP Prompt**: Replaced the extensive documentation with a concise, principle-based prompt that emphasizes proper tool usage patterns
+- **NixOS 25.05 Beta Channel Support**: Added support for the upcoming NixOS 25.05 release
+- **New "beta" Alias**: Added a "beta" alias that maps to the current beta channel (currently 25.05)
+- **Comprehensive Channel Documentation**: Updated all docstrings to include information about the new beta channel
+- **Enhanced Testing**: Added extensive tests to ensure proper channel functionality
 
 ### 🛠️ Implementation Details
 
-- **Channel Validation**: Added proper validation to ensure channel switching actually retrieves distinct data
-- **Context Type Consistency**: Standardized context handling across NixOS, Home Manager, and Darwin tools
-- **Enhanced Parameter Documentation**: Improved documentation for the `ctx` parameter across all tools
-- **Comprehensive Testing**: Added new tests for channel switching and context handling
+- **Channel Validation**: Extended channel validation to include the new 25.05 Beta channel
+- **Cache Management**: Ensured cache clearing behavior works correctly with the new channel
+- **Alias Handling**: Implemented proper handling of the "beta" alias similar to the "stable" alias
+- **Testing**: Comprehensive test suite to verify all aspects of channel switching and alias resolution
 
 ## Technical Details
 
-The release addresses two main architectural issues:
+The release implements the following key improvements:
 
-1. **Channel Switching Failure**: Previously, switching between channels (like "unstable" and "24.11") didn't properly change the Elasticsearch index, resulting in identical data regardless of channel selection. This has been fixed with proper verification of channel differences.
+1. **25.05 Beta Channel**: Added the Elasticsearch index mapping for the upcoming NixOS 25.05 release using the index name pattern `latest-42-nixos-25.05`
 
-2. **Context Management Chaos**: The codebase had inconsistent handling of the `ctx` parameter across different tools, sometimes treating it as a request context object and other times as a string identifier. This has been standardized with proper type checking and appropriate handling for all context types.
+2. **Beta Alias**: Implemented a "beta" alias that will always point to the current beta channel, similar to how the "stable" alias points to the current stable release
 
-3. **Dynamic Discovery**: Following MCP best practices, tools now support dynamic discovery rather than requiring hardcoded documentation in the prompt, making the system more maintainable and scalable.
+3. **Extended Documentation**: Updated all function and parameter docstrings to include the new channel options, ensuring users know about the full range of available channels
+
+4. **Future-Proofing**: Designed the implementation to make it easy to add new channels in the future when new NixOS releases are in development
 
 ## Installation
 
 ```bash
 # Install with pip
-pip install mcp-nixos==0.4.0
+pip install mcp-nixos==0.5.0
 
 # Install with uv
-uv pip install mcp-nixos==0.4.0
+uv pip install mcp-nixos==0.5.0
 
 # Install with uvx
-uvx mcp-nixos==0.4.0
+uvx mcp-nixos==0.5.0
 ```
 
 ## Usage
@@ -56,6 +58,25 @@ Configure Claude to use the tool by adding it to your `~/.config/claude/config.j
     }
   ]
 }
+```
+
+### Available Channels
+
+The following channels are now available for all NixOS tools:
+
+- `unstable` - The NixOS unstable development branch
+- `25.05` - The NixOS 25.05 Beta release (upcoming)
+- `beta` - Alias for the current beta channel (currently 25.05)
+- `24.11` - The current stable NixOS release
+- `stable` - Alias for the current stable release (currently 24.11)
+
+Example usage:
+```python
+# Search packages in the beta channel
+nixos_search(query="nginx", channel="beta")
+
+# Get information about a package in the 25.05 channel
+nixos_info(name="python3", type="package", channel="25.05")
 ```
 
 ## Contributors

--- a/mcp_nixos/__init__.py
+++ b/mcp_nixos/__init__.py
@@ -12,7 +12,7 @@ try:
         __version__ = version("mcp-nixos")
     except PackageNotFoundError:
         # Package is not installed, use a default version
-        __version__ = "0.4.0"
+        __version__ = "0.5.0"
 except ImportError:
     # Fallback for Python < 3.8
     try:
@@ -20,4 +20,4 @@ except ImportError:
 
         __version__ = pkg_resources.get_distribution("mcp-nixos").version
     except Exception:
-        __version__ = "0.4.0"
+        __version__ = "0.5.0"

--- a/mcp_nixos/clients/elasticsearch_client.py
+++ b/mcp_nixos/clients/elasticsearch_client.py
@@ -29,8 +29,10 @@ DEFAULT_READ_TIMEOUT = 10.0
 # Channel to Index mapping
 AVAILABLE_CHANNELS = {
     "unstable": "latest-42-nixos-unstable",
+    "25.05": "latest-42-nixos-25.05",  # Beta channel
+    "beta": "latest-42-nixos-25.05",  # Alias for beta
     "24.11": "latest-42-nixos-24.11",
-    "stable": "latest-42-nixos-24.11",  # Alias
+    "stable": "latest-42-nixos-24.11",  # Alias for stable
 }
 DEFAULT_CHANNEL = "unstable"
 
@@ -129,10 +131,13 @@ class ElasticsearchClient:
         # Normalize channel name to lowercase
         ch_lower = channel.lower()
 
-        # First check if we need to handle the stable alias
+        # First check if we need to handle aliases
         if ch_lower == "stable":
             logger.debug("Converting 'stable' alias to actual channel name: 24.11")
             ch_lower = "24.11"  # Always convert stable to the actual version
+        elif ch_lower == "beta":
+            logger.debug("Converting 'beta' alias to actual channel name: 25.05")
+            ch_lower = "25.05"  # Always convert beta to the actual version
 
         # Then check if the channel is valid
         if ch_lower not in self.available_channels:

--- a/mcp_nixos/tools/nixos_tools.py
+++ b/mcp_nixos/tools/nixos_tools.py
@@ -468,9 +468,17 @@ def _format_option_info(info: Dict[str, Any], channel: str) -> str:
 def nixos_search(
     query: str, type: str = "packages", limit: int = 20, channel: str = CHANNEL_UNSTABLE, context=None
 ) -> str:
-    """
-    Search for NixOS packages, options, or programs.
-    ... (Args/Returns docstring) ...
+    """Search for NixOS packages, options, or programs.
+
+    Args:
+        query: The search term
+        type: The type to search (packages, options, or programs)
+        limit: Maximum number of results to return (default: 20)
+        channel: NixOS channel to use (default: unstable, options: unstable, 24.11, 25.05, beta, stable)
+        context: Optional context object (used internally)
+
+    Returns:
+        Formatted search results as text
     """
     logger.info(f"Searching NixOS '{channel}' for {type} matching '{query}' (limit {limit})")
     search_type = type.lower()
@@ -541,9 +549,16 @@ def nixos_search(
 
 
 def nixos_info(name: str, type: str = "package", channel: str = CHANNEL_UNSTABLE, context=None) -> str:
-    """
-    Get detailed information about a NixOS package or option.
-    ... (Args/Returns docstring) ...
+    """Get detailed information about a NixOS package or option.
+
+    Args:
+        name: The name of the package or option
+        type: Either "package" or "option"
+        channel: NixOS channel to use (default: unstable, options: unstable, 24.11, 25.05, beta, stable)
+        context: Optional context object (used internally)
+
+    Returns:
+        Detailed information about the package or option
     """
     logger.info(f"Getting NixOS '{channel}' {type} info for: {name}")
     info_type = type.lower()
@@ -584,9 +599,14 @@ def nixos_info(name: str, type: str = "package", channel: str = CHANNEL_UNSTABLE
 
 
 def nixos_stats(channel: str = CHANNEL_UNSTABLE, context=None) -> str:
-    """
-    Get statistics about available NixOS packages and options.
-    ... (Args/Returns docstring) ...
+    """Get statistics about available NixOS packages and options.
+
+    Args:
+        channel: NixOS channel to use (default: unstable, options: unstable, 24.11, 25.05, beta, stable)
+        context: Optional context object (used internally)
+
+    Returns:
+        Statistics about packages and options
     """
     logger.info(f"Getting NixOS statistics for channel '{channel}'")
 
@@ -671,7 +691,7 @@ def register_nixos_tools(mcp) -> None:
             query: The search term
             type: The type to search (packages, options, or programs)
             limit: Maximum number of results to return (default: 20)
-            channel: NixOS channel to use (default: unstable)
+            channel: NixOS channel to use (default: unstable, options: unstable, 24.11, 25.05, beta, stable)
 
         Returns:
             Results formatted as text
@@ -715,7 +735,7 @@ def register_nixos_tools(mcp) -> None:
         Args:
             name: The name of the package or option
             type: Either "package" or "option"
-            channel: NixOS channel to use (default: unstable)
+            channel: NixOS channel to use (default: unstable, options: unstable, 24.11, 25.05, beta, stable)
 
         Returns:
             Detailed information about the package or option
@@ -757,7 +777,7 @@ def register_nixos_tools(mcp) -> None:
         """Get statistics about available NixOS packages and options.
 
         Args:
-            channel: NixOS channel to use (default: unstable)
+            channel: NixOS channel to use (default: unstable, options: unstable, 24.11, 25.05, beta, stable)
 
         Returns:
             Statistics about packages and options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-nixos"
-version = "0.4.0"
+version = "0.5.0"
 description = "Model Context Protocol server for NixOS, Home Manager, and nix-darwin resources"
 readme = "README.md"
 authors = [

--- a/tests/clients/test_channel_switching_fix.py
+++ b/tests/clients/test_channel_switching_fix.py
@@ -103,6 +103,110 @@ class TestChannelSwitchingFix(unittest.TestCase):
         self.assertEqual(self.client._current_channel_id, different_channel_id)
         self.assertNotEqual(original_channel_id, self.client._current_channel_id)
 
+    def test_25_05_beta_channel_support(self):
+        """Test support for the NixOS 25.05 Beta channel."""
+        # Reset counter
+        self.cache_clear_count = 0
+
+        # Verify 25.05 is in available channels
+        self.assertIn("25.05", self.client.available_channels, "25.05 channel not found in available channels")
+
+        # Get index ID for 25.05 channel
+        beta_channel_id = self.client.available_channels["25.05"]
+        self.assertTrue(beta_channel_id.endswith("-25.05"), "25.05 channel ID doesn't have proper suffix")
+
+        # Set channel to 25.05 and verify it updates correctly
+        self.client.set_channel("25.05")
+        self.assertEqual(self.client._current_channel_id, beta_channel_id, "Failed to set channel to 25.05")
+        self.assertEqual(self.cache_clear_count, 1, "Cache should be cleared when switching to 25.05")
+
+        # URLs should be updated with the correct index
+        self.assertIn(beta_channel_id, self.client.es_packages_url, "URL not updated with 25.05 index")
+        self.assertIn(beta_channel_id, self.client.es_options_url, "URL not updated with 25.05 index")
+
+        # Switching between multiple channels should work correctly
+        # 25.05 -> unstable
+        self.client.set_channel("unstable")
+        self.assertEqual(self.cache_clear_count, 2, "Cache should be cleared when switching from 25.05 to unstable")
+
+        # unstable -> 24.11
+        self.client.set_channel("24.11")
+        self.assertEqual(self.cache_clear_count, 3, "Cache should be cleared when switching to 24.11")
+
+        # 24.11 -> 25.05
+        self.client.set_channel("25.05")
+        self.assertEqual(self.cache_clear_count, 4, "Cache should be cleared when switching back to 25.05")
+
+        # 25.05 -> stable (which is 24.11)
+        self.client.set_channel("stable")
+        self.assertEqual(self.cache_clear_count, 5, "Cache should be cleared when switching from 25.05 to stable")
+
+        # Get current channel name after setting to "stable"
+        stable_channel_id = self.client._current_channel_id
+        stable_channel_name = next(
+            name
+            for name, cid in self.client.available_channels.items()
+            if cid == stable_channel_id and name != "stable"
+        )
+        self.assertEqual(stable_channel_name, "24.11", "Stable channel should map to 24.11")
+
+    def test_stable_channel_alias_preserved(self):
+        """Test that the stable channel alias is still mapped to 24.11 after adding 25.05."""
+        # Verify stable still maps to 24.11
+        self.assertEqual(
+            self.client.available_channels["stable"],
+            self.client.available_channels["24.11"],
+            "Stable channel should still map to 24.11",
+        )
+
+        # Set channel to stable
+        self.client.set_channel("stable")
+
+        # Get the elasticsearch index ID that was actually used
+        current_index = self.client._current_channel_id
+
+        # Verify it's the same as 24.11
+        self.assertEqual(
+            current_index, self.client.available_channels["24.11"], "Stable should resolve to the same index as 24.11"
+        )
+
+    def test_beta_channel_alias(self):
+        """Test that the beta channel alias is correctly mapped to 25.05."""
+        # Verify beta maps to 25.05
+        self.assertEqual(
+            self.client.available_channels["beta"],
+            self.client.available_channels["25.05"],
+            "Beta channel should map to 25.05",
+        )
+
+        # Reset counter
+        self.cache_clear_count = 0
+
+        # Set channel to beta
+        self.client.set_channel("beta")
+
+        # Get the elasticsearch index ID that was actually used
+        current_index = self.client._current_channel_id
+
+        # Verify it's the same as 25.05
+        self.assertEqual(
+            current_index, self.client.available_channels["25.05"], "Beta should resolve to the same index as 25.05"
+        )
+
+        # Get the current cache_clear_count to avoid depending on previous state
+        current_count = self.cache_clear_count
+
+        # Set to a different channel and then back to beta to verify cache clearing
+        self.client.set_channel("unstable")
+        self.assertEqual(
+            self.cache_clear_count, current_count + 1, "Cache should be cleared when switching from beta to unstable"
+        )
+
+        self.client.set_channel("beta")
+        self.assertEqual(
+            self.cache_clear_count, current_count + 2, "Cache should be cleared when switching back to beta"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -47,7 +47,7 @@ def test_version_fallback_package_not_found(mock_version):
     import mcp_nixos
 
     # Check that the default version is used
-    assert mcp_nixos.__version__ == "0.4.0"
+    assert mcp_nixos.__version__ == "0.5.0"
     mock_version.assert_called_once_with("mcp-nixos")
 
 
@@ -80,5 +80,5 @@ def test_version_ultimate_fallback(mock_get_distribution, _):
     import mcp_nixos
 
     # Check that the default version is used when everything fails
-    assert mcp_nixos.__version__ == "0.4.0"
+    assert mcp_nixos.__version__ == "0.5.0"
     mock_get_distribution.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "mcp-nixos"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
- Add 25.05 beta channel and matching Elasticsearch index
- Create beta alias pointing to current beta channel (25.05)
- Update channel handling in set_channel method for beta alias
- Add comprehensive tests for beta channel support
- Update all docstrings to include new channel options
- Bump version to 0.5.0 and update RELEASE_NOTES.md

🤖 Generated with [Claude Code](https://claude.ai/code)