### PR TITLE
Set meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
           pkgs.python311Packages.buildPythonApplication {
             pname = pyproject.project.name;
             inherit (pyproject.project) version;
+            meta.mainProgram = pyproject.project.name;
             
             src = ./.;
             


### PR DESCRIPTION
Prevents Nix from printing the following error:
```
evaluation warning: getExe: Package "mcp-nixos-1.0.0" does not have the meta.mainProgram attribute. We'll assume that > the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when > the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to > make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```