### PR TITLE
feat: Improve CI/CD with separated workflows and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,82 @@
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# GitHub
+.github/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+*.egg
+.eggs/
+dist/
+build/
+wheels/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+*.cover
+.hypothesis/
+.tox/
+.venv/
+venv/
+ENV/
+env/
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Nix
+result
+result-*
+.direnv/
+.envrc
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Documentation
+LICENSE
+docs/
+website/
+CLAUDE.md
+RELEASE_NOTES.md
+!README.md
+
+# Development
+.mcp.json
+CLAUDE.md
+tests/
+conftest.py
+*.test.py
+*_test.py
+
+# CI/CD
+.travis.yml
+.gitlab-ci.yml
+azure-pipelines.yml
+
+# Other
+.env
+.env.*
+*.log
+*.bak
+*.tmp
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
 
@@ -43,6 +43,7 @@ jobs:
         uv run mypy mcp_nixos/
     
     - name: Test with pytest
+      timeout-minutes: 10
       run: |
         uv run pytest -v --cov=mcp_nixos --cov-report=xml --cov-report=term
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
     
     - name: Check package
       run: |
+        uv pip install twine
         uv run twine check dist/*
     
     - name: Upload artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,324 +1,161 @@
-# .github/workflows/ci.yml
-#
-# Simplified CI/CD workflow that actually works:
-# - Skips tests for documentation-only changes (on branches only)
-# - Publishes to PyPI on any version tag (v*)
-
 name: CI
 
 on:
-  # Push events - only on main branch or version tags
   push:
-    branches: [main]
-    tags: ["v*"]
-  # Pull requests - only when targeting main branch
+    branches: [ main ]
   pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
-  # Manual trigger
-  workflow_dispatch:
+    branches: [ main ]
 
-# Cancel in-progress runs when a new commit is pushed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+permissions:
+  contents: read
 
 jobs:
-  # Detect what changed to determine if we need to run tests (for branches only)
-  changes:
-    name: Detect Changes
+  test:
     runs-on: ubuntu-latest
-    # Only run change detection for non-tag events
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-      docs: ${{ steps.filter.outputs.docs }}
-      website: ${{ steps.filter.outputs.website }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Check for changes
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            code:
-              - 'mcp_nixos/**'
-              - 'tests/**'
-              - 'pyproject.toml'
-              - 'setup.py'
-              - 'requirements.txt'
-              - 'flake.nix'
-              - 'flake.lock'
-              - '.github/workflows/**'
-            docs:
-              - '*.md'
-              - 'LICENSE'
-              - '.env.example'
-            website:
-              - 'website/**'
-
-  # Python matrix test job - tests on multiple Python versions
-  test-python:
-    name: Test Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    needs: [changes]
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-    # Always evaluate this condition, even if changes job was skipped
-    if: |
-      always() && (
-        startsWith(github.ref, 'refs/tags/') ||
-        (needs.changes.result == 'success' && needs.changes.outputs.code == 'true' &&
-         (github.event_name == 'pull_request' ||
-          (github.event_name == 'push' && !contains(github.event.head_commit.message, 'Merge pull request'))))
-      )
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-      
-      - name: Install dependencies
-        run: |
-          uv pip install --system -e ".[dev]"
-      
-      - name: Format check
-        run: ruff format --check mcp_nixos/ tests/
-      
-      - name: Lint
-        run: ruff check mcp_nixos/ tests/
-      
-      - name: Type check
-        run: mypy mcp_nixos/
-      
-      - name: Run tests
-        run: |
-          pytest tests/ -v --cov=mcp_nixos --cov-report=term --cov-report=xml --junitxml=junit.xml
-      
-      - name: Upload coverage to Codecov
-        if: always()
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: false
-          flags: python-${{ matrix.python-version }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      
-      - name: Upload test results to Codecov
-        if: always()
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./junit.xml
 
-  # Nix flake test job - only tests with Python 3.12
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: "**/pyproject.toml"
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        uv sync --all-extras --dev
+    
+    - name: Lint with ruff
+      run: |
+        uv run ruff check mcp_nixos/ tests/
+        uv run ruff format --check mcp_nixos/ tests/
+    
+    - name: Type check with mypy
+      run: |
+        uv run mypy mcp_nixos/
+    
+    - name: Test with pytest
+      run: |
+        uv run pytest -v --cov=mcp_nixos --cov-report=xml --cov-report=term
+    
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.12'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: utensils/mcp-nixos
+        files: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+    
+    - name: Set up Python
+      run: uv python install 3.12
+    
+    - name: Build package
+      run: |
+        uv build
+    
+    - name: Check package
+      run: |
+        uv run twine check dist/*
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-packages
+        path: dist/
+
   test-nix:
-    name: Test Nix Flake
     runs-on: ubuntu-latest
-    needs: [changes]
-    # Always evaluate this condition, even if changes job was skipped
-    if: |
-      always() && (
-        startsWith(github.ref, 'refs/tags/') ||
-        (needs.changes.result == 'success' && needs.changes.outputs.code == 'true' &&
-         (github.event_name == 'pull_request' ||
-          (github.event_name == 'push' && !contains(github.event.head_commit.message, 'Merge pull request'))))
-      )
+    
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
-      
-      - name: Cache Nix store
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/nix
-          key: ${{ runner.os }}-nix-${{ hashFiles('flake.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-nix-
-      
-      - name: Build flake
-        run: |
-          nix flake check --accept-flake-config
-          nix develop -c echo "Development environment ready"
-      
-      - name: Test nix run
-        run: |
-          timeout 5s nix run . -- --help || true
-      
-      - name: Run tests in nix develop
-        run: |
-          echo "Running tests in nix environment"
-          nix develop --command setup
-          nix develop --command bash -c 'run-tests'
+    - uses: actions/checkout@v4
+    
+    - name: Install Nix
+      uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          accept-flake-config = true
+    
+    - name: Cache Nix store
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/nix
+        key: ${{ runner.os }}-nix-${{ hashFiles('flake.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-nix-
+    
+    - name: Build flake
+      run: |
+        nix flake check --accept-flake-config
+        nix develop -c echo "Development environment ready"
+    
+    - name: Test nix run
+      run: |
+        timeout 5s nix run . -- --help || true
+    
+    - name: Run tests in nix develop
+      run: |
+        echo "Running tests in nix environment"
+        nix develop --command setup
+        nix develop --command bash -c 'run-tests'
 
-  # Website deployment - only on main branch pushes with changes
+  # Website deployment - only on main branch pushes
   deploy-website:
-    name: Deploy Website
-    needs: [changes]
     runs-on: ubuntu-latest
-    # Only deploy if changes were detected and we're on main
-    if: |
-      needs.changes.result == 'success' &&
-      needs.changes.outputs.website == 'true' &&
-      github.ref == 'refs/heads/main' && 
-      github.event_name == 'push' &&
-      !contains(github.event.head_commit.message, 'Merge pull request')
+    needs: [test, build]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: AWS
       url: https://mcp-nixos.utensils.io
     permissions:
       id-token: write
+    
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: website/package-lock.json
+    
+    - name: Build and Deploy
+      run: |
+        cd website
+        npm install
+        npm run build
       
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: website/package-lock.json
-      
-      - name: Build and Deploy
-        run: |
-          cd website
-          npm install
-          npm run build
-        
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      
-      - name: Deploy to S3
-        run: |
-          aws s3 sync website/out/ s3://urandom-mcp-nixos/ --delete
-          aws cloudfront create-invalidation --distribution-id E1QS1G7FYYJ6TL --paths "/*"
-
-  # Publish to TestPyPI - on all pushes to main and on tags
-  publish-test:
-    name: Publish to TestPyPI
-    needs: [test-python, test-nix]
-    if: |
-      always() &&
-      needs.test-python.result == 'success' &&
-      needs.test-nix.result == 'success' &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/mcp-nixos
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
-      
-      - name: Build package
-        run: |
-          nix develop --command build
-          ls -l dist/
-      
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
-  # PyPI publishing - only on version tags after TestPyPI succeeds
-  publish:
-    name: Publish to PyPI
-    needs: [test-python, test-nix, publish-test]
-    if: |
-      always() &&
-      needs.test-python.result == 'success' &&
-      needs.test-nix.result == 'success' &&
-      needs.publish-test.result == 'success' &&
-      startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/mcp-nixos
-    permissions:
-      id-token: write
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
-      
-      - name: Build package
-        run: |
-          nix develop --command build
-          ls -l dist/
-      
-      - name: Verify package
-        run: |
-          python3 -m venv test-env
-          source test-env/bin/activate
-          pip install dist/*.whl
-          python -c "import mcp_nixos; print(f'Version: {mcp_nixos.__version__}')"
-      
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-      
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      
-      - name: Extract release notes
-        id: extract_notes
-        run: |
-          # Extract release notes for this version from RELEASE_NOTES.md
-          awk '/^# MCP-NixOS: v${{ steps.version.outputs.version }}/ {flag=1; next} /^# MCP-NixOS: v[0-9]/ {if(flag) exit} flag' RELEASE_NOTES.md > release_notes.txt
-          echo "Release notes extracted"
-      
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          body_path: release_notes.txt
-          draft: false
-          prerelease: false
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    
+    - name: Deploy to S3
+      run: |
+        aws s3 sync website/out/ s3://urandom-mcp-nixos/ --delete
+        aws cloudfront create-invalidation --distribution-id E1QS1G7FYYJ6TL --paths "/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     
     - name: Check package
       run: |
-        uv pip install twine
+        uv sync --extra dev
         uv run twine check dist/*
     
     - name: Upload artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
@@ -32,20 +32,20 @@ jobs:
     - name: Install dependencies
       run: |
         uv sync --extra dev
-    
+
     - name: Lint with ruff
       run: |
         uv run ruff check mcp_nixos/ tests/
         uv run ruff format --check mcp_nixos/ tests/
-    
+
     - name: Type check with mypy
       run: |
         uv run mypy mcp_nixos/
-    
+
     - name: Test with pytest
       timeout-minutes: 10
       run: |
-        uv run pytest -v --cov=mcp_nixos --cov-report=xml --cov-report=term
+        uv run pytest -v -n auto --cov=mcp_nixos --cov-report=xml --cov-report=term
     
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.12'
@@ -60,7 +60,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: test
     
     steps:
     - uses: actions/checkout@v4
@@ -93,7 +92,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v27
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -126,7 +125,7 @@ jobs:
   # Website deployment - only on main branch pushes
   deploy-website:
     runs-on: ubuntu-latest
-    needs: [test, build]
+    needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: AWS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        uv sync --all-extras --dev
+        uv sync --extra dev
     
     - name: Lint with ruff
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,121 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy-test:
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Nix
+      uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          accept-flake-config = true
+    
+    - name: Build package with Nix
+      run: |
+        nix develop --command build
+        ls -la dist/
+    
+    - name: Publish package to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  deploy-prod:
+    needs: deploy-test
+    runs-on: ubuntu-latest
+    # Only deploy to PyPI for non-prerelease versions
+    if: ${{ !github.event.release.prerelease }}
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Nix
+      uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          accept-flake-config = true
+    
+    - name: Build package with Nix
+      run: |
+        nix develop --command build
+        ls -la dist/
+    
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  docker:
+    needs: deploy-test
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          utensils/mcp-nixos
+          ghcr.io/utensils/mcp-nixos
+        tags: |
+          # Latest tag for stable releases
+          type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+          # Version tag from release
+          type=semver,pattern={{version}}
+          # Major.minor tag
+          type=semver,pattern={{major}}.{{minor}}
+          # Major tag (only for stable releases)
+          type=semver,pattern={{major}},enable=${{ !github.event.release.prerelease }}
+    
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v27
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v27
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -75,10 +75,10 @@ jobs:
     
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-    
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    
+
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
@@ -91,7 +91,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
@@ -110,7 +110,7 @@ jobs:
           type=semver,pattern={{major}},enable=${{ !github.event.release.prerelease }}
     
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal final image
-FROM python:3.13-alpine AS builder
+FROM python:3.13-alpine3.22 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \
@@ -18,7 +18,7 @@ COPY mcp_nixos/ ./mcp_nixos/
 RUN pip wheel --no-cache-dir --wheel-dir /wheels .
 
 # Final stage
-FROM python:3.13-alpine
+FROM python:3.13-alpine3.22
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,49 @@
-FROM python:3.11-slim
+# Multi-stage build for minimal final image
+FROM python:3.13-alpine AS builder
 
-WORKDIR /app
+# Install build dependencies
+RUN apk add --no-cache \
+    gcc \
+    musl-dev \
+    libffi-dev
+
+# Set working directory
+WORKDIR /build
 
 # Copy project files
-COPY . .
+COPY pyproject.toml README.md ./
+COPY mcp_nixos/ ./mcp_nixos/
 
-# Install the package and dependencies
-RUN pip install --no-cache-dir -e .
+# Build wheel
+RUN pip wheel --no-cache-dir --wheel-dir /wheels .
+
+# Final stage
+FROM python:3.13-alpine
 
 # Set environment variables
-ENV PYTHONUNBUFFERED=1
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Install runtime dependencies
+RUN apk add --no-cache libffi
+
+# Create non-root user
+RUN adduser -D -h /app mcp
+
+# Set working directory
+WORKDIR /app
+
+# Copy wheels from builder
+COPY --from=builder /wheels /wheels
+
+# Install the package
+RUN pip install --no-cache-dir /wheels/* && \
+    rm -rf /wheels
+
+# Switch to non-root user
+USER mcp
 
 # Run the MCP server
-CMD ["python", "-m", "mcp_nixos"]
+ENTRYPOINT ["python", "-m", "mcp_nixos.server"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@
 }
 ```
 
+### Option 3: Using Docker (Container lovers unite)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=nixos&config=eyJjb21tYW5kIjoiZG9ja2VyIiwiYXJncyI6WyJydW4iLCItLXJtIiwiLWkiLCJnaGNyLmlvL3V0ZW5zaWxzL21jcC1uaXhvcyJdfQ%3D%3D)
+```json
+{
+  "mcpServers": {
+    "nixos": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "ghcr.io/utensils/mcp-nixos"]
+    }
+  }
+}
+```
+
 That's it. Your AI assistant now has access to real NixOS data instead of making things up. You're welcome.
 
 ## What Is This Thing?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "pytest-asyncio>=1.1.0",
+    "pytest-xdist>=3.6.0",
     "ruff>=0.12.4",
     "mypy>=1.17.0",
     "types-beautifulsoup4>=4.12.0.20250516",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -398,6 +398,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "fastmcp"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -737,6 +746,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "twine" },
     { name = "types-beautifulsoup4" },
@@ -755,6 +765,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "pywin32", marker = "extra == 'win'", specifier = ">=308.0" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.4" },
@@ -1140,6 +1151,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Split CI and publish workflows for cleaner separation of concerns
- Add Docker support with multi-stage Alpine-based build (133MB image size)
- Configure dual publishing to both Docker Hub and GitHub Container Registry

## Changes
### CI/CD Improvements
- **Separated workflows**: `ci.yml` for testing/building, `publish.yml` for releases
- **Smart publishing**: Pre-releases (v1.0.0-beta.1) go to TestPyPI, stable releases go to PyPI
- **Clean CI workflow**: Uses modern `uv` tooling, tests on Python 3.11/3.12/3.13

### Docker Support
- **Multi-stage Alpine build**: Minimal final image using Python 3.13-alpine
- **Security**: Runs as non-root user `mcp`
- **Dual registry**: Publishes to both `utensils/mcp-nixos` (Docker Hub) and `ghcr.io/utensils/mcp-nixos`
- **Added Docker option to README**: Users can now run via Docker with proper MCP configuration

### Documentation
- Updated CLAUDE.md with required header for Claude Code
- Added architectural overview and development workflows
- Added Docker installation option with Cursor deeplink button

## Test Plan
- [x] Docker build tested locally (`docker build -t mcp-nixos:test .`)
- [x] Docker run tested with MCP protocol
- [x] Image size verified (133MB)
- [ ] CI workflow will run on this PR
- [ ] Publishing workflow will be tested on next release