### PR TITLE
feat: Add manual workflow dispatch for Docker builds to fix GHCR access

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,17 @@ name: Publish Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      docker_only:
+        description: 'Build and push Docker images only (skip PyPI)'
+        required: false
+        type: boolean
+        default: true
+      tag:
+        description: 'Git tag to build from (e.g., v1.0.1)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -11,12 +22,16 @@ permissions:
 jobs:
   deploy-test:
     runs-on: ubuntu-latest
+    # Skip PyPI deployment when manually triggered with docker_only
+    if: ${{ github.event_name == 'release' || !inputs.docker_only }}
     environment: testpypi
     permissions:
       id-token: write
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag || github.ref }}
     
     - name: Install Nix
       uses: cachix/install-nix-action@v31
@@ -39,14 +54,16 @@ jobs:
   deploy-prod:
     needs: deploy-test
     runs-on: ubuntu-latest
-    # Only deploy to PyPI for non-prerelease versions
-    if: ${{ !github.event.release.prerelease }}
+    # Only deploy to PyPI for non-prerelease versions and skip when manually triggered with docker_only
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease && (github.event_name == 'release' || !inputs.docker_only) }}
     environment: pypi
     permissions:
       id-token: write
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag || github.ref }}
     
     - name: Install Nix
       uses: cachix/install-nix-action@v31
@@ -65,13 +82,17 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
   docker:
-    needs: deploy-test
+    # Run if: (1) release event after test deploy, or (2) manual trigger
+    needs: [deploy-test]
+    if: ${{ always() && (github.event_name == 'release' && needs.deploy-test.result == 'success') || (github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    
+
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag || github.ref }}
     
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -100,14 +121,14 @@ jobs:
           utensils/mcp-nixos
           ghcr.io/utensils/mcp-nixos
         tags: |
-          # Latest tag for stable releases
-          type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
-          # Version tag from release
-          type=semver,pattern={{version}}
+          # Latest tag for stable releases (not for prereleases)
+          type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
+          # Version tag from release or manual input
+          type=semver,pattern={{version}},value=${{ inputs.tag || github.ref_name }}
           # Major.minor tag
-          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
           # Major tag (only for stable releases)
-          type=semver,pattern={{major}},enable=${{ !github.event.release.prerelease }}
+          type=semver,pattern={{major}},value=${{ inputs.tag || github.ref_name }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
     
     - name: Build and push Docker image
       uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
     needs: deploy-test
     runs-on: ubuntu-latest
     # Only deploy to PyPI for non-prerelease versions and skip when manually triggered with docker_only
-    if: ${{ github.event_name == 'release' && !github.event.release.prerelease && (github.event_name == 'release' || !inputs.docker_only) }}
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease && !inputs.docker_only }}
     environment: pypi
     permissions:
       id-token: write
@@ -83,8 +83,8 @@ jobs:
 
   docker:
     # Run if: (1) release event after test deploy, or (2) manual trigger
-    needs: [deploy-test]
-    if: ${{ always() && (github.event_name == 'release' && needs.deploy-test.result == 'success') || (github.event_name == 'workflow_dispatch') }}
+    # Note: Docker builds are independent and don't strictly require PyPI deployment
+    if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -93,7 +93,33 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.tag || github.ref }}
-    
+
+    - name: Validate tag format
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\-\.]+)?$ ]]; then
+          echo "❌ Invalid tag format. Expected: v1.2.3 or v1.2.3-alpha"
+          exit 1
+        fi
+
+    - name: Verify tag exists
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        if ! git rev-parse --verify "refs/tags/${{ inputs.tag }}" >/dev/null 2>&1; then
+          echo "❌ Tag ${{ inputs.tag }} does not exist"
+          exit 1
+        fi
+        echo "✓ Tag ${{ inputs.tag }} verified"
+
+    - name: Normalize tag
+      id: tag
+      run: |
+        if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+        else
+          echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
@@ -105,7 +131,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -124,11 +150,11 @@ jobs:
           # Latest tag for stable releases (not for prereleases)
           type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
           # Version tag from release or manual input
-          type=semver,pattern={{version}},value=${{ inputs.tag || github.ref_name }}
+          type=semver,pattern={{version}},value=${{ steps.tag.outputs.tag }}
           # Major.minor tag
-          type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.tag }}
           # Major tag (only for stable releases)
-          type=semver,pattern={{major}},value=${{ inputs.tag || github.ref_name }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
+          type=semver,pattern={{major}},value=${{ steps.tag.outputs.tag }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
     
     - name: Build and push Docker image
       uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

Fixes #48 - Adds manual workflow dispatch capability to the publish workflow, enabling Docker image builds to both Docker Hub and GitHub Container Registry (GHCR) without requiring a new release.

## Problem

Users cannot pull Docker images from `ghcr.io/utensils/mcp-nixos` because:
- The publish workflow is configured to push to GHCR (lines 88-114 of publish.yml)
- However, Docker images haven't been built for recent releases (v1.0.0, v1.0.1)
- Users get "unauthorized" errors when trying to pull from GHCR

## Solution

Added `workflow_dispatch` trigger to the publish workflow with:

1. **Manual trigger capability**: Can be run from GitHub Actions UI
2. **Tag input**: Specify which git tag to build (e.g., `v1.0.1`)
3. **Docker-only mode**: Skip PyPI publishing (default: true)
4. **Smart job conditions**:
   - PyPI jobs skip when `docker_only` is true
   - Docker job runs for both release events and manual triggers
   - Proper ref checkout using `inputs.tag` for manual runs

## Changes

- Added `workflow_dispatch` event trigger with inputs for `tag` and `docker_only`
- Updated all jobs to check out the correct ref based on trigger type
- Modified job conditions to handle manual triggers appropriately
- Updated metadata extraction to work with manual tag inputs

## Test Plan

- [x] Validate YAML syntax
- [x] Commit and push changes
- [ ] After PR merge: Manually trigger workflow with `tag: v1.0.1` to build missing images
- [ ] Verify images are pushed to both Docker Hub and GHCR
- [ ] Test pulling from `ghcr.io/utensils/mcp-nixos:latest`
- [ ] Test pulling from `ghcr.io/utensils/mcp-nixos:1.0.1`

## Usage

After merge, maintainers can:
1. Go to Actions → Publish Package workflow
2. Click "Run workflow"
3. Enter tag (e.g., `v1.0.1`)
4. Leave "docker_only" checked
5. Run to build and push Docker images for that tag

This will resolve the GHCR access issue by building the missing Docker images for v1.0.1.